### PR TITLE
Adding facilities to block out automatic updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,13 @@ ENV NR_PHP_AGENT_URL 'https://download.newrelic.com/php_agent/archive/10.6.0.318
 ENV DEBIAN_FRONTEND=noninteractive
 ENV NUKE_PERMISSIONS=true
 ENV REMOVE_CRAP_PLUGINS=true
+ENV PREVENT_UPDATES true
+
+# The "Hardening WordPress" article at https://wordpress.org/documentation/article/hardening-wordpress/
+# recommends 755 and 644
+ENV FILE_OWNER 'www-data:www-data'
+ENV FILE_MODE 444
+ENV DIRECTORY_MODE 555
 
 # Install PHP and related packages, plus locales
 COPY ./bin/install_packages.sh /root/install_packages.sh
@@ -21,7 +28,11 @@ RUN /root/configure_nginx.sh
 
 WORKDIR /var/www/html
 
-COPY ./wordpress_site/ .
+COPY mu-plugins/ /root/mu-plugins/
+RUN mkdir mu-plugins
+RUN if [ $PREVENT_UPDATES ]; then cp /root/mu-plugins/dockpress-prevent-updates.php mu-plugins/; fi
+
+COPY wordpress_site/ .
 
 # If there was no index.php file located in the site/ directory, we fetch a fresh installation of WordPress
 RUN if [ ! -f index.php ]; then wp core download --allow-root; fi

--- a/bin/nuke_permissions.sh
+++ b/bin/nuke_permissions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-chown -R www-data:www-data .
-find . -type d -exec chmod 755 {} \;
-find . -type f -exec chmod 644 {} \;
+chown -R $FILE_OWNER .
+find . -type f -not -path "./.git/*" -not -path "./wp-content/uploads/*" -exec chmod $DIRECTORY_MODE {} \;
+find . -type f -not -path "./.git/*" -not -path "./wp-content/uploads/*" -exec chmod $FILE_MODE {} \;

--- a/mu-plugins/dockpress-prevent-updates.php
+++ b/mu-plugins/dockpress-prevent-updates.php
@@ -1,0 +1,6 @@
+<?php
+
+# Prevent automatic updates for themes and plugins in order to ensure that the
+# site is immutable
+add_filter( 'auto_update_plugin', '__return_false' );
+add_filter( 'auto_update_theme', '__return_false' );


### PR DESCRIPTION
- Setting DISALLOW_FILE_EDIT and WP_AUTO_UPDATE_CORE
- Making file permissions read only
- Defining and using file permissions as environment variables