### PR TITLE
Adding optional Ghostscript/GhostPDL installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,6 @@ ENV LANG en_US.utf8
 COPY ./bin/install_ghostscript.sh /root/install_ghostscript.sh
 RUN if [ $INSTALL_GHOSTSCRIPT ]; then bash /root/install_ghostscript.sh; fi
 
-COPY bin/install_ghostscript.sh /root/install_ghostscript.sh
-RUN /root/install_ghostscript.sh
-
 # Copy over our nginx site config
 COPY ./nginx_config/default_site /etc/nginx/sites-enabled/default
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ EXPOSE 80
 
 ENV NR_PHP_AGENT_URL 'https://download.newrelic.com/php_agent/archive/10.6.0.318/newrelic-php5-10.6.0.318-linux.tar.gz'
 
+ENV INSTALL_GHOSTSCRIPT true
+
 ENV WP_INSTALL_IF_NOT_FOUND true
 # ENV FORCE_WP_CONFIG true
 
@@ -35,6 +37,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY ./bin/install_packages.sh /root/install_packages.sh
 RUN bash /root/install_packages.sh
 ENV LANG en_US.utf8
+
+# Install Ghostscript
+COPY ./bin/install_ghostscript.sh /root/install_ghostscript.sh
+RUN if [ $INSTALL_GHOSTSCRIPT ]; then bash /root/install_ghostscript.sh; fi
+
+COPY bin/install_ghostscript.sh /root/install_ghostscript.sh
+RUN /root/install_ghostscript.sh
 
 # Copy over our nginx site config
 COPY ./nginx_config/default_site /etc/nginx/sites-enabled/default

--- a/bin/install_ghostscript.sh
+++ b/bin/install_ghostscript.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install build-essential libtiff-dev -y
+sudo apt-get remove php8.1-imagick -y
+sudo apt-get install build-essential libtiff-dev zlib1g-dev libfontconfig-dev \
+                     libfreetype-dev libgvc6 libheif-dev liblcms2-dev \
+                     libopenjp2-7-dev liblqr-1-0-dev libopenexr-dev \
+                     libpango1.0-dev libraw-dev libwmf-dev libxml2-dev \
+                     libzip-dev libzstd-dev libdjvulibre-dev libraqm-dev \
+                     libwebp-dev libltdl-dev php8.1-dev -y
 
-curl -s -L "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs1000/ghostpdl-10.0.0.tar.gz" | tar -C /tmp -zx
+curl -s -L "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs1000/ghostscript-10.0.0.tar.gz" | tar -C /tmp -zx
+cd /tmp/ghostpdl-* && ./configure CFLAGS=-O3 --prefix=/usr && make -j $(nproc) so && make soinstall
+rm -rf /tmp/ghostpdl-*
+ldconfig
 
-cd /tmp/ghostpdl-10.0.0 && ./configure --prefix=/usr && make && make install
+curl -s -L https://imagemagick.org/archive/ImageMagick-6.9.12-81.tar.gz | tar -C /tmp -zx
+cd /tmp/ImageMagick-* && ./configure CFLAGS=-O3 --with-modules --with-gslib=yes && make -j $(nproc) && make install
+rm -rf /tmp/ImageMagick-*
+ldconfig
+
+curl -s -L https://pecl.php.net/get/imagick-3.7.0.tgz | tar -C /tmp -zx
+cd /tmp/imagick-* && phpize && ./configure CFLAGS=-O3 --with-imagick=/opt/local && make -j $(nproc) && make install
+rm -rf /tmp/imagick-*
+ldconfig
+
+echo "extension=imagick.so" > /etc/php/8.1/mods-available/imagick
+phpenmod imagick

--- a/bin/install_ghostscript.sh
+++ b/bin/install_ghostscript.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sudo apt-get update
+sudo apt-get install build-essential libtiff-dev -y
+
+curl -s -L "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs1000/ghostpdl-10.0.0.tar.gz" | tar -C /tmp -zx
+
+cd /tmp/ghostpdl-10.0.0 && ./configure --prefix=/usr && make && make install

--- a/bin/install_packages.sh
+++ b/bin/install_packages.sh
@@ -6,7 +6,7 @@ add-apt-repository ppa:ondrej/php
 apt-get install sudo nginx php8.1-fpm php8.1 \
                 php8.1-mysqli php8.1-curl php8.1-memcached php8.1-memcache \
                 php8.1-zip php8.1-dom php8.1-mbstring -y php8.1-imagick \
-                php8.1-redis php8.1-bc php8.1-gd php8.1-intl php8.1-ssh2 \
+                php8.1-redis php8.1-bc php8.1-intl php8.1-ssh2 \
                 mariadb-client curl locales jq less -y
 
 rm -rf /var/lib/apt/lists/*

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,10 @@ for.
 * Facilitates the installation of and runs the **New Relic** PHP Agent, which is used for system monitoring
 * Facilitiates changing image URLs to point to a different server (like a CDN)
 * Optionally installs and configures **Ghostscript/GhostPDL**
+<<<<<<< HEAD
 * Includes documentation on **Kubernetes** deployment
+=======
+>>>>>>> 5effee4 (Adding optional Ghostscript/GhostPDL installer)
 
 ## A quick note
 
@@ -151,6 +154,20 @@ storage and runs the built-in update mechanism,
 This also ensures that the WordPress installation is immutable and makes it less
 likely that the site is exploited by and falls victim to code injection.
 
+### Ghostscript (GhostPDL) installation
+
+Set the `INSTALL_GHOSTSCRIPT` environment variable to enable the installation of
+Ghostscript (as a part of the larger GhostPDL package).
+
+Ghostpress may take a while to build from source.
+
+Note that while *open source*, Ghostscript and GhostPDL are, like this package,
+licenced under the GNU Affero General Public License by Artifex Software Inc and
+availabe commerically as well.
+
+Please check [Artiflex's licencing information](https://artifex.com/licensing/)
+for more information on their licencing terms.
+
 ## Further Technical Stuff
 
 ### Volume mounts
@@ -199,6 +216,13 @@ docker push $registry_path
 ```
 
 ## Licence
+
+This software is licenced according to and is subject to the GNU Affero General
+Public License (AGPL), with the possibility of an exception upon request.
+
+The 3rd party software that it installs during build is generally subject to the
+GPL licence or other highly permissive licences, with the exception of
+Ghostscript/GhostPDL, which is also distributed according to the AGPL.
 
 Please do not hesistate to contact the author to enquire about a license
 exception or if there are questions about appropriate use of this software.


### PR DESCRIPTION
Note: Ghostscript is licensed under the AGPL licence, so Ghostscript needs to be optional and there needs to be a note on that in the readme.

Closes #30