### PR TITLE
Adding a wait for uploads to finish and sync with a CDN

### DIFF
--- a/bin/configure_wordpress.sh
+++ b/bin/configure_wordpress.sh
@@ -61,9 +61,9 @@ then
 
     # Configure the CDN urls and scope, if enabled
 
-    if [ $CDN_CONTENT_URL ]
+    if [ $WP_CONTENT_URL ]
     then
-        wp config set WP_CONTENT_URL "$CDN_CONTENT_URL" --allow-root
+        wp config set WP_CONTENT_URL "$WP_CONTENT_URL" --allow-root
     fi
 fi
 

--- a/mu-plugins/dockpress-delay-uploads-until-synced-with-cdn.php
+++ b/mu-plugins/dockpress-delay-uploads-until-synced-with-cdn.php
@@ -1,0 +1,20 @@
+<?php
+
+if (defined('WP_CONTENT_URL') || defined('UPLOADS_URL')) {
+    add_action(
+        'wp_handle_upload',
+        'dockpress_delay_upload_until_synced_with_cdn'
+    );
+}
+
+function dockpress_delay_upload_until_synced_with_cdn($file) {
+    $i = 0;
+    while($i < 5) {
+        sleep(5);
+        $check_headers = get_headers($url);
+        if (str_contains($check_headers[0], '200')) {
+            return $file;
+        }
+    }
+    return $file;
+}

--- a/mu-plugins/dockpress-filter-uploads-url.php
+++ b/mu-plugins/dockpress-filter-uploads-url.php
@@ -1,4 +1,5 @@
 <?php
+
 if (defined('UPLOADS_URL')) {
     add_filter(
         'pre_option_upload_url_path',


### PR DESCRIPTION
This is done when the constants WP_CONTENT_URL and UPLOADS_URL are set.

Closes #31 