### PR TITLE
Removing software-properties-common

### DIFF
--- a/bin/install_packages.sh
+++ b/bin/install_packages.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 apt-get update
-apt-get install software-properties-common -y
 apt-get dist-upgrade -y
 apt-get install nginx php8.1-fpm php8.1 \
                 php8.1-mysql php8.1-curl php8.1-memcached php8.1-memcache \


### PR DESCRIPTION
Removing `software-properties-common` as we were only using it for PHP8 backports, which are now longer needed for Ubuntu.

This was also the source of a CVE in a Python package.