### PR TITLE
Installing php8.1-imagick by default

### DIFF
--- a/bin/install_packages.sh
+++ b/bin/install_packages.sh
@@ -4,14 +4,9 @@ apt-get update
 apt-get dist-upgrade -y
 apt-get install nginx php8.1-fpm php8.1 \
                 php8.1-mysql php8.1-curl php8.1-memcached php8.1-memcache \
-                php8.1-zip php8.1-xml php8.1-mbstring \
+                php8.1-zip php8.1-xml php8.1-mbstring php8.1-imagick \
                 php8.1-redis php8.1-bc php8.1-intl php8.1-ssh2 \
                 mariadb-client curl locales jq less python3-pip -y
-
-if [ ! $INSTALL_GHOSTSCRIPT ]
-then
-    apt-get install php8.1-imagick
-fi
 
 rm -rf /var/lib/apt/lists/*
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
This removes the $INSTALL_GHOSTSCRIPT condition and installs it along with all the other packages.