### PR TITLE
Adding an HTTP header to indicate the site runs DockPress

### DIFF
--- a/nginx_config/default_site
+++ b/nginx_config/default_site
@@ -35,4 +35,6 @@ server {
         deny all;
         return 403;
     }
+
+    add_header X-DockPress "This site uses DockPress to manage WordPress in the cloud. https://github.com/aldavigdis/dockpress";
 }


### PR DESCRIPTION
The purpose of this is to proof the use of the system that may or may not be violating the AGPL licence.